### PR TITLE
docs: add TigreGotico attribution, link ILENIA

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ currently two models are available, [conformer-CTC](https://huggingface.co/HiTZ/
 
 ## Credits
 
+This plugin was developed by [TigreGotico](https://tigregotico.pt) for OpenVoiceOS under the [ILENIA](https://proyectoilenia.es) project.
+
 <img src="img.png" width="128"/>
 
-> This plugin was funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU – NextGenerationEU within the framework of the project ILENIA with reference 2022/TL22/00215337
+> This plugin was funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU – NextGenerationEU within the framework of the project [ILENIA](https://proyectoilenia.es) with reference 2022/TL22/00215337
 
 <img src="img_1.png"  width="64"/>
 


### PR DESCRIPTION
Adds the standard TigreGotico developer credit and links ILENIA to proyectoilenia.es in the credits section.